### PR TITLE
Fix android breaking change RN >= 0.47

### DIFF
--- a/android/src/main/java/com/RNOpenpay/RNOpenpayPackage.java
+++ b/android/src/main/java/com/RNOpenpay/RNOpenpayPackage.java
@@ -13,11 +13,6 @@ import com.facebook.react.uimanager.ViewManager;
 public class RNOpenpayPackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
React Native 0.47 removed createJSModules on Android 

