### PR TITLE
RN version older than 0.47 and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,25 @@ react-native link react-native-openpay
 
 ## Manually link
 ### Android
+* in `android/app/build.gradle`:
+```diff
+dependencies {
+    ...
+    compile "com.facebook.react:react-native:+"  // From node_modules
++   compile project(':react-native-openpay')
+}
+```
+* in `android/settings.gradle`:
+```diff
+...
+include ':app'
++ include ':react-native-openpay'
++ project(':react-native-openpay').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-openpay/android')
+
+```
+
 **With React Native 0.29+**
-* In `MainApplication.java`
+* in `MainApplication.java`
 ```diff
 + import com.RNOpenpay.RNOpenpayPackage;
 
@@ -39,7 +56,7 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 **With older versions of React Native:**
-* In `MainActivity.java`
+* in `MainActivity.java`
 ```diff
 + import com.RNOpenpay.RNOpenpayPackage;
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,45 @@ then link the library to Android/iOS native projects (i havent tested `rnpm` for
 react-native link react-native-openpay
 ```
 
+## Manually link
+### Android
+**With React Native 0.29+**
+* In `MainApplication.java`
+```diff
++ import com.RNOpenpay.RNOpenpayPackage;
+
+public class MainApplication extends Application implements ReactApplication {
+    // .......
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
++         new RNOpenpayPackage(),
+          new MainReactPackage()
+      );
+    }
+    
+    // ......
+}
+```
+**With older versions of React Native:**
+* In `MainActivity.java`
+```diff
++ import com.RNOpenpay.RNOpenpayPackage;
+
+public class MainActivity extends ReactActivity {
+    // ......
+    
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
++       new RNOpenpayPackage(),
+        new MainReactPackage()
+      );
+    }
+    
+    // .....
+}
+```
 ## Usage
 
 before doing anything, setup your instance with your credentials:

--- a/android/src/main/java/com/RNOpenpay/RNOpenpayPackage.java
+++ b/android/src/main/java/com/RNOpenpay/RNOpenpayPackage.java
@@ -17,6 +17,11 @@ public class RNOpenpayPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
+    // Deprecated RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();


### PR DESCRIPTION
## What does this PR?
* Fix Android crash on RN version older than 0.47
* Add Manually link for Android on README.md